### PR TITLE
meson.build: add custom dependency for easy usage as subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,3 +17,7 @@ subdir('include')
 subdir('src')
 subdir('example')
 subdir('demo')
+
+gtk_layer_shell_dep = declare_dependency(
+    link_with: gtk_layer_shell_lib,
+    include_directories: gtk_layer_shell_inc)


### PR DESCRIPTION
With a dependency gtk-layer-shell can be used as a submodule very easily:

```
gtk_layer_shell = dependency('gtk-layer-shell-0', fallback: ['gtk-layer-shell', 'gtk_layer_shell_dep'])
```