### PR TITLE
Build versioned library

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,7 @@ gtk_layer_shell_lib = library('gtk-layer-shell',
     layer_shell_client_header, layer_shell_private_code,
     include_directories: [gtk_layer_shell_inc],
     dependencies: [gtk, wayland_client],
+    version: meson.project_version(),
     install: true)
 
 pkg_config_name = 'gtk-layer-shell-0'


### PR DESCRIPTION
Some distributions (at least Fedora) prohibit packaging unversioned .so libraries.
This is a minimal change to generate versioned libgtk-layer-shell.so.0*. Feel free to discard this if you have more sophisticated library versioning scheme in mind.