### PR TITLE
Allow users to set size along a non-anchored axis

### DIFF
--- a/demo/gtk-layer-demo.c
+++ b/demo/gtk-layer-demo.c
@@ -7,6 +7,7 @@ static int default_margins[] = {0, 0, 0, 0};
 
 static gboolean default_auto_exclusive_zone = FALSE; // always set by command line option
 static gboolean default_keyboard_interactivity = FALSE; // always set by command line option
+static gboolean default_fixed_size = FALSE; // always set by command line option
 
 const char *prog_name = "gtk-layer-demo";
 const char *prog_summary = "A GTK application for demonstrating the functionality of the Layer Shell Wayland protocol";
@@ -62,6 +63,15 @@ static const GOptionEntry options[] = {
         .arg = G_OPTION_ARG_NONE,
         .arg_data = &default_keyboard_interactivity,
         .description = "Enable keyboard interactivity",
+        .arg_description = NULL,
+    },
+    {
+        .long_name = "fixed-size",
+        .short_name = 'f',
+        .flags = G_OPTION_FLAG_NONE,
+        .arg = G_OPTION_ARG_NONE,
+        .arg_data = &default_fixed_size,
+        .description = "Enable a fixed window size",
         .arg_description = NULL,
     },
     { NULL, 0, 0, 0, NULL, NULL, NULL }

--- a/demo/gtk-layer-demo.c
+++ b/demo/gtk-layer-demo.c
@@ -235,7 +235,7 @@ on_orientation_changed (GtkWindow *window, WindowOrientation orientation, Toplev
     }
     gtk_orientable_set_orientation (GTK_ORIENTABLE (data->toplevel_box), orient_toplevel);
     gtk_orientable_set_orientation (GTK_ORIENTABLE (data->first_box), orient_sub);
-    // gtk_orientable_set_orientation (GTK_ORIENTABLE (data->second_box), orient_sub);
+    gtk_orientable_set_orientation (GTK_ORIENTABLE (data->second_box), orient_sub);
     gtk_window_resize (window, 1, 1); // force the window to shrink to the smallest size it can
 }
 
@@ -293,16 +293,17 @@ layer_window_new ()
                                 FALSE, FALSE, 0);
         }
     }{
-        GtkWidget *vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 12);
-        gtk_box_pack_start (GTK_BOX (data->toplevel_box), vbox, FALSE, FALSE, 0);
+        data->second_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 12);
+        gtk_box_pack_start (GTK_BOX (data->toplevel_box), data->second_box, FALSE, FALSE, 0);
         {
-            data->second_box = mscl_toggles_new (gtk_window,
+            GtkWidget *toggles_box = mscl_toggles_new (gtk_window,
                                                  default_auto_exclusive_zone,
-                                                 default_keyboard_interactivity);
-            gtk_box_pack_start (GTK_BOX (vbox),
-                                data->second_box,
+                                                 default_keyboard_interactivity,
+                                                 default_fixed_size);
+            gtk_box_pack_start (GTK_BOX (data->second_box),
+                                toggles_box,
                                 FALSE, FALSE, 0);
-            gtk_box_pack_start (GTK_BOX (vbox),
+            gtk_box_pack_start (GTK_BOX (data->second_box),
                                 margin_control_new (gtk_window, default_margins),
                                 FALSE, FALSE, 0);
         }

--- a/demo/gtk-layer-demo.h
+++ b/demo/gtk-layer-demo.h
@@ -38,7 +38,8 @@ margin_control_new (GtkWindow *layer_window, const int default_margins[GTK_LAYER
 GtkWidget *
 mscl_toggles_new (GtkWindow *layer_window,
                   gboolean default_auto_exclusive_zone,
-                  gboolean default_keyboard_interactivity);
+                  gboolean default_keyboard_interactivity,
+                  gboolean default_fixed_size);
 
 GtkWidget *
 menu_bar_new (GtkWindow *layer_window);

--- a/demo/margin-control.c
+++ b/demo/margin-control.c
@@ -96,6 +96,8 @@ margin_control_new (GtkWindow *layer_window, const int default_margins[GTK_LAYER
     gtk_container_add (GTK_CONTAINER (popover), switch_box);
     gtk_widget_show_all (switch_box);
     g_signal_connect (open_button, "clicked", G_CALLBACK (on_open_clicked), popover);
+    GtkWidget *padding_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+    gtk_box_pack_start (GTK_BOX (padding_box), open_button, TRUE, FALSE, 0);
 
-    return open_button;
+    return padding_box;
 }

--- a/demo/mscl-toggles.c
+++ b/demo/mscl-toggles.c
@@ -28,11 +28,11 @@ on_fixed_size_set (GtkToggleButton *_toggle_button, gboolean state, GtkWindow *l
     (void)_toggle_button;
 
     if (state) {
-        gtk_window_set_default_size (layer_window, 600, 600);
+        gtk_widget_set_size_request (GTK_WIDGET (layer_window), 600, 500);
     } else {
-        gtk_window_set_default_size (layer_window, -1, -1);
+        gtk_widget_set_size_request (GTK_WIDGET (layer_window), -1, -1);
     }
-    gtk_widget_queue_resize (GTK_WIDGET (layer_window));
+    gtk_window_resize (layer_window, 1, 1);
     return FALSE;
 }
 

--- a/demo/mscl-toggles.c
+++ b/demo/mscl-toggles.c
@@ -22,6 +22,20 @@ on_keyboard_interactivity_state_set (GtkToggleButton *_toggle_button, gboolean s
     return FALSE;
 }
 
+gboolean
+on_fixed_size_set (GtkToggleButton *_toggle_button, gboolean state, GtkWindow *layer_window)
+{
+    (void)_toggle_button;
+
+    if (state) {
+        gtk_window_set_default_size (layer_window, 600, 600);
+    } else {
+        gtk_window_set_default_size (layer_window, -1, -1);
+    }
+    gtk_widget_queue_resize (GTK_WIDGET (layer_window));
+    return FALSE;
+}
+
 struct {
     const char *name;
     const char *tooltip;
@@ -29,12 +43,14 @@ struct {
 } const mscl_toggles[] = {
     {"Exclusive", "Create an exclusive zone when anchored", on_exclusive_zone_state_set},
     {"Keyboard", "Get keyboard events", on_keyboard_interactivity_state_set},
+    {"Set Size", "Set a fixed window size", on_fixed_size_set},
 };
 
 GtkWidget *
 mscl_toggles_new (GtkWindow *layer_window,
                   gboolean default_auto_exclusive_zone,
-                  gboolean default_keyboard_interactivity)
+                  gboolean default_keyboard_interactivity,
+                  gboolean default_fixed_size)
 {
     GtkWidget *vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
     for (unsigned i = 0; i < sizeof (mscl_toggles) / sizeof (mscl_toggles[0]); i++) {
@@ -51,6 +67,8 @@ mscl_toggles_new (GtkWindow *layer_window,
                 default_value = default_auto_exclusive_zone;
             else if (mscl_toggles[i].callback == on_keyboard_interactivity_state_set)
                 default_value = default_keyboard_interactivity;
+            else if (mscl_toggles[i].callback == on_fixed_size_set)
+                default_value = default_fixed_size;
             else
                 g_assert_not_reached ();
             gtk_switch_set_active (GTK_SWITCH (toggle), default_value);

--- a/include/gtk-layer-shell.h
+++ b/include/gtk-layer-shell.h
@@ -21,6 +21,16 @@ typedef enum {
     GTK_LAYER_SHELL_EDGE_ENTRY_NUMBER, // Should not be used except to get the number of entries
 } GtkLayerShellEdge;
 
+// FORCING WINDOW SIZE
+// If you wish to force your layer surface window to be a different size than it is by default:
+/*
+gtk_widget_set_size_request (GTK_WIDGET (layer_gtk_window), width, height);
+gtk_window_resize (layer_gtk_window, 1, 1); // force the window to resize to the new request
+*/
+// If width or height is -1, the default is used for that axis. If the window is anchored to opposite edges of the
+// output (see gtk_layer_set_anchor ()), the size request is ignored. If you later wish to use the default window size,
+// simply repeat the two calls but with both width and height as -1.
+
 // Set the window up to be a layer surface once it is mapped
 // This must be called before the window is realized
 void gtk_layer_init_for_window (GtkWindow *window);

--- a/src/layer-surface.c
+++ b/src/layer-surface.c
@@ -40,24 +40,25 @@ layer_surface_update_size (LayerSurface *self)
 {
     GtkWindow *gtk_window = custom_shell_surface_get_gtk_window ((CustomShellSurface *)self);
 
-    GtkRequisition size_request = (GtkRequisition) {
-        .width = -1,
-        .height = -1,
-    };
+    GdkGeometry hints;
+    hints.min_width = -1;
+    hints.min_height = -1;
 
     if ((self->anchors[GTK_LAYER_SHELL_EDGE_LEFT]) &&
         (self->anchors[GTK_LAYER_SHELL_EDGE_RIGHT])) {
 
-        size_request.width = self->last_configure_size.width;
+        hints.min_width = self->last_configure_size.width;
     }
     if ((self->anchors[GTK_LAYER_SHELL_EDGE_TOP]) &&
         (self->anchors[GTK_LAYER_SHELL_EDGE_BOTTOM])) {
 
-        size_request.height = self->last_configure_size.height;
+        hints.min_height = self->last_configure_size.height;
     }
 
-    gtk_widget_set_size_request (GTK_WIDGET (gtk_window), size_request.width, size_request.height);
-    gtk_window_resize (gtk_window, 1, 1); // shrink the window to its size request
+    gtk_window_set_geometry_hints (gtk_window,
+                                   NULL,
+                                   &hints,
+                                   GDK_HINT_MIN_SIZE);
 }
 
 static void

--- a/src/layer-surface.c
+++ b/src/layer-surface.c
@@ -209,6 +209,9 @@ static const CustomShellSurfaceVirtual layer_surface_virtual = {
 static void
 layer_surface_update_auto_exclusive_zone (LayerSurface *self)
 {
+    if (!self->auto_exclusive_zone)
+        return;
+
     gboolean horiz = (self->anchors[GTK_LAYER_SHELL_EDGE_LEFT] ==
                       self->anchors[GTK_LAYER_SHELL_EDGE_RIGHT]);
     gboolean vert = (self->anchors[GTK_LAYER_SHELL_EDGE_TOP] ==
@@ -276,8 +279,7 @@ layer_surface_on_size_allocate (GtkWidget *_gtk_window,
             }
         }
 
-        if (self->auto_exclusive_zone)
-            layer_surface_update_auto_exclusive_zone (self);
+        layer_surface_update_auto_exclusive_zone (self);
     }
 }
 
@@ -363,8 +365,7 @@ layer_surface_set_anchor (LayerSurface *self, GtkLayerShellEdge edge, gboolean a
         if (self->layer_surface) {
             layer_surface_send_set_anchor (self);
             layer_surface_update_size (self);
-            if (self->auto_exclusive_zone)
-                layer_surface_update_auto_exclusive_zone (self);
+            layer_surface_update_auto_exclusive_zone (self);
             custom_shell_surface_needs_commit ((CustomShellSurface *)self);
         }
     }
@@ -377,8 +378,7 @@ layer_surface_set_margin (LayerSurface *self, GtkLayerShellEdge edge, int margin
     if (margin_size != self->margins[edge]) {
         self->margins[edge] = margin_size;
         layer_surface_send_set_margin (self);
-        if (self->auto_exclusive_zone)
-            layer_surface_update_auto_exclusive_zone (self);
+        layer_surface_update_auto_exclusive_zone (self);
         custom_shell_surface_needs_commit ((CustomShellSurface *)self);
     }
 }


### PR DESCRIPTION
This hopefully fixes #24 without breaking #11 again. It also adds a new toggle to gtk-layer-demo that can be used to test. Before merging, I hope to get approval from both @ammen99 and @hraisins confirming it works for their use cases (test with your actual projects, not just gtk-layer-demo). How to use (as explained in the public header):

> If you wish to force your layer surface window to be a different size than it is by default:
```c
gtk_widget_set_size_request (GTK_WIDGET (layer_gtk_window), width, height);
gtk_window_resize (layer_gtk_window, 1, 1); // force the window to resize to the new request
```
> If width or height is -1, the default is used for that axis. If the window is anchored to opposite edges of the output (see `gtk_layer_set_anchor ()`), the size request is ignored. If you later wish to use the default window size, simply repeat the two calls but with both width and height as -1.