### PR TITLE
Fix resizing on new configure

### DIFF
--- a/src/layer-surface.c
+++ b/src/layer-surface.c
@@ -69,24 +69,25 @@ layer_surface_update_size (LayerSurface *self)
 {
     GtkWindow *gtk_window = custom_shell_surface_get_gtk_window ((CustomShellSurface *)self);
 
-    GdkGeometry hints;
-    hints.min_width =
-    hints.max_width =
-    hints.min_height =
-    hints.max_height = -1;
+    gint width = -1;
+    gint height = -1;
 
     if ((self->anchors[GTK_LAYER_SHELL_EDGE_LEFT]) &&
         (self->anchors[GTK_LAYER_SHELL_EDGE_RIGHT])) {
 
-        hints.min_width =
-        hints.max_width = self->last_configure_size.width;
+        width = self->last_configure_size.width;
     }
     if ((self->anchors[GTK_LAYER_SHELL_EDGE_TOP]) &&
         (self->anchors[GTK_LAYER_SHELL_EDGE_BOTTOM])) {
 
-        hints.min_height =
-        hints.max_height = self->last_configure_size.height;
+        height = self->last_configure_size.height;
     }
+
+    GdkGeometry hints;
+    hints.min_width = width;
+    hints.max_width = width;
+    hints.min_height = height;
+    hints.max_height = height;
 
     gtk_window_set_geometry_hints (gtk_window,
                                    NULL,

--- a/src/layer-surface.c
+++ b/src/layer-surface.c
@@ -70,24 +70,28 @@ layer_surface_update_size (LayerSurface *self)
     GtkWindow *gtk_window = custom_shell_surface_get_gtk_window ((CustomShellSurface *)self);
 
     GdkGeometry hints;
-    hints.min_width = -1;
-    hints.min_height = -1;
+    hints.min_width =
+    hints.max_width =
+    hints.min_height =
+    hints.max_height = -1;
 
     if ((self->anchors[GTK_LAYER_SHELL_EDGE_LEFT]) &&
         (self->anchors[GTK_LAYER_SHELL_EDGE_RIGHT])) {
 
-        hints.min_width = self->last_configure_size.width;
+        hints.min_width =
+        hints.max_width = self->last_configure_size.width;
     }
     if ((self->anchors[GTK_LAYER_SHELL_EDGE_TOP]) &&
         (self->anchors[GTK_LAYER_SHELL_EDGE_BOTTOM])) {
 
-        hints.min_height = self->last_configure_size.height;
+        hints.min_height =
+        hints.max_height = self->last_configure_size.height;
     }
 
     gtk_window_set_geometry_hints (gtk_window,
                                    NULL,
                                    &hints,
-                                   GDK_HINT_MIN_SIZE);
+                                   GDK_HINT_MIN_SIZE | GDK_HINT_MAX_SIZE);
 
     // This will usually get called in a moment by the layer_surface_on_size_allocate () triggered by the above
     // gtk_window_set_geometry_hints (). However in some cases (such as a streatching a window after a size request has
@@ -113,7 +117,7 @@ layer_surface_handle_configure (void *data,
         .height = (gint)h,
     };
 
-    layer_surface_update_size(self);
+    layer_surface_update_size (self);
 }
 
 static void

--- a/src/layer-surface.c
+++ b/src/layer-surface.c
@@ -35,6 +35,11 @@ struct _LayerSurface
     struct zwlr_layer_surface_v1 *layer_surface;
 };
 
+/*
+ * Sends the .set_size request if the current allocation differs from the last size sent
+ * Needs to be called whenever current_allocation or anchors are changed
+ * If .set_size is sent, it should trigger the compositor to send a .configure event
+ */
 static void
 layer_surface_send_set_size (LayerSurface *self)
 {
@@ -64,6 +69,12 @@ layer_surface_send_set_size (LayerSurface *self)
     }
 }
 
+/*
+ * Sets the window's geometry hints (used to force the window to be a specific size)
+ * Needs to be called whenever last_configure_size or anchors are changed
+ * Lets windows decide their own size along any axis the surface is not stretched along
+ * Forces window (by setting the max and min hints) to be of configured size along axises they are stretched along
+ */
 static void
 layer_surface_update_size (LayerSurface *self)
 {


### PR DESCRIPTION
This fixes cases in which the size of the output becomes smaller in a stretched direction. Easy to test with `gtk-layer-demo` by running it in a Sway instance nested under Wayland/X and shrinking the Sway window. I'd like to get approval from both @ammen99 and @hraisins that this doesn't break anything before merging (I'm pretty confident it fixes the bug it intends to, just not that it doesn't break any other use cases).