### PR TITLE
Use layer_surface->set_layer instead of remapping when available

### DIFF
--- a/src/gtk-wayland.c
+++ b/src/gtk-wayland.c
@@ -49,7 +49,7 @@ wl_registry_handle_global (void *_data,
 
     // pull out needed globals
     if (strcmp (interface, zwlr_layer_shell_v1_interface.name) == 0) {
-        g_warn_if_fail (zwlr_layer_shell_v1_interface.version == 1);
+        g_warn_if_fail (zwlr_layer_shell_v1_interface.version == 3);
         layer_shell_global = wl_registry_bind (registry,
                                                id,
                                                &zwlr_layer_shell_v1_interface,

--- a/src/layer-surface.c
+++ b/src/layer-surface.c
@@ -356,7 +356,13 @@ layer_surface_set_layer (LayerSurface *self, enum zwlr_layer_shell_v1_layer laye
     if (self->layer != layer) {
         self->layer = layer;
         if (self->layer_surface) {
-            custom_shell_surface_remap ((CustomShellSurface *)self);
+            uint32_t version = zwlr_layer_surface_v1_get_version (self->layer_surface);
+            if (version >= ZWLR_LAYER_SURFACE_V1_SET_LAYER_SINCE_VERSION) {
+                zwlr_layer_surface_v1_set_layer (self->layer_surface, self->layer);
+                custom_shell_surface_needs_commit ((CustomShellSurface *)self);
+            } else {
+                custom_shell_surface_remap ((CustomShellSurface *)self);
+            }
         }
     }
 }

--- a/src/protocol/wlr-layer-shell-unstable-v1.xml
+++ b/src/protocol/wlr-layer-shell-unstable-v1.xml
@@ -25,7 +25,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zwlr_layer_shell_v1" version="1">
+  <interface name="zwlr_layer_shell_v1" version="3">
     <description summary="create surfaces that are layers of the desktop">
       Clients can use this interface to assign the surface_layer role to
       wl_surfaces. Such surfaces are assigned to a "layer" of the output and
@@ -82,17 +82,27 @@
       <entry name="top" value="2"/>
       <entry name="overlay" value="3"/>
     </enum>
+
+    <!-- Version 3 additions -->
+
+    <request name="destroy" type="destructor" since="3">
+      <description summary="destroy the layer_shell object">
+        This request indicates that the client will not use the layer_shell
+        object any more. Objects that have been created through this instance
+        are not affected.
+      </description>
+    </request>
   </interface>
 
-  <interface name="zwlr_layer_surface_v1" version="1">
+  <interface name="zwlr_layer_surface_v1" version="3">
     <description summary="layer metadata interface">
       An interface that may be implemented by a wl_surface, for surfaces that
       are designed to be rendered as a layer of a stacked desktop-like
       environment.
 
-      Layer surface state (size, anchor, exclusive zone, margin, interactivity)
-      is double-buffered, and will be applied at the time wl_surface.commit of
-      the corresponding wl_surface is called.
+      Layer surface state (layer, size, anchor, exclusive zone,
+      margin, interactivity) is double-buffered, and will be applied at the
+      time wl_surface.commit of the corresponding wl_surface is called.
     </description>
 
     <request name="set_size">
@@ -127,14 +137,19 @@
 
     <request name="set_exclusive_zone">
       <description summary="configures the exclusive geometry of this surface">
-        Requests that the compositor avoids occluding an area of the surface
-        with other surfaces. The compositor's use of this information is
+        Requests that the compositor avoids occluding an area with other
+        surfaces. The compositor's use of this information is
         implementation-dependent - do not assume that this region will not
         actually be occluded.
 
-        A positive value is only meaningful if the surface is anchored to an
-        edge, rather than a corner. The zone is the number of surface-local
-        coordinates from the edge that is considered exclusive.
+        A positive value is only meaningful if the surface is anchored to one
+        edge or an edge and both perpendicular edges. If the surface is not
+        anchored, anchored to only two perpendicular edges (a corner), anchored
+        to only two parallel edges or anchored to all edges, a positive value
+        will be treated the same as zero.
+
+        A positive zone is the distance from the edge in surface-local
+        coordinates to consider exclusive.
 
         Surfaces that do not wish to have an exclusive zone may instead specify
         how they should interact with surfaces that do. If set to zero, the
@@ -281,5 +296,16 @@
       <entry name="left" value="4" summary="the left edge of the anchor rectangle"/>
       <entry name="right" value="8" summary="the right edge of the anchor rectangle"/>
     </enum>
+
+    <!-- Version 2 additions -->
+
+    <request name="set_layer" since="2">
+      <description summary="change the layer of the surface">
+        Change the layer that the surface is rendered on.
+
+        Layer is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="layer" type="uint" enum="zwlr_layer_shell_v1.layer" summary="layer to move this surface to"/>
+    </request>
   </interface>
 </protocol>


### PR DESCRIPTION
Just a minor change to avoid remapping when the compositor implements zwlr_layer_surface_v1 version 2+.
Tested on sway with gtk-layer-demo.