### PR TITLE
Fix grabbing popups

### DIFF
--- a/src/custom-shell-surface.c
+++ b/src/custom-shell-surface.c
@@ -40,7 +40,7 @@ custom_shell_surface_on_window_realize (GtkWidget *widget, CustomShellSurface *s
     GdkWindow *gdk_window = gtk_widget_get_window (GTK_WIDGET (self->private->gtk_window));
     g_return_if_fail (gdk_window);
 
-    gdk_window_hack_init (gdk_window);
+    gtk_priv_access_init (gdk_window);
     gdk_wayland_window_set_use_custom_surface (gdk_window);
 }
 

--- a/src/gtk-priv-access.c
+++ b/src/gtk-priv-access.c
@@ -41,7 +41,7 @@ typedef void (*MoveToRectFunc) (GdkWindow *window,
 static MoveToRectFunc gdk_window_move_to_rect_real = NULL;
 
 static GdkWindow *
-gdk_window_hack_get_transient_for (GdkWindow *gdk_window)
+gdk_window_get_priv_transient_for (GdkWindow *gdk_window)
 {
     GdkWindow *window_transient_for = gdk_window_priv_get_transient_for (gdk_window);
     GdkWindowImplWayland *window_impl = (GdkWindowImplWayland *)gdk_window_priv_get_impl (gdk_window);
@@ -74,7 +74,7 @@ gdk_window_move_to_rect_impl_override (GdkWindow *window,
                                   rect_anchor_dx,
                                   rect_anchor_dy);
 
-    GdkWindow *transient_for_gdk_window = gdk_window_hack_get_transient_for (window);
+    GdkWindow *transient_for_gdk_window = gdk_window_get_priv_transient_for (window);
     CustomShellSurface *transient_for_shell_surface = NULL;
     GdkWindow *toplevel_gdk_window = transient_for_gdk_window;
     while (toplevel_gdk_window) {
@@ -83,7 +83,7 @@ gdk_window_move_to_rect_impl_override (GdkWindow *window,
         transient_for_shell_surface = gtk_window_get_custom_shell_surface (toplevel_gtk_window);
         if (transient_for_shell_surface)
             break;
-        toplevel_gdk_window = gdk_window_hack_get_transient_for (toplevel_gdk_window);
+        toplevel_gdk_window = gdk_window_get_priv_transient_for (toplevel_gdk_window);
     }
     if (transient_for_shell_surface) {
         g_return_if_fail (rect);
@@ -104,7 +104,7 @@ gdk_window_move_to_rect_impl_override (GdkWindow *window,
 }
 
 void
-gdk_window_hack_init (GdkWindow *gdk_window)
+gtk_priv_access_init (GdkWindow *gdk_window)
 {
     // Don't do anything once this has run successfully once
     if (gdk_window_move_to_rect_real)

--- a/src/gtk-priv-access.h
+++ b/src/gtk-priv-access.h
@@ -16,6 +16,6 @@
 
 // This only has an effect the first time it's called
 // It enables gtk_window_hack_get_position () working later
-void gdk_window_hack_init (GdkWindow *gdk_window);
+void gtk_priv_access_init (GdkWindow *gdk_window);
 
 #endif // GDK_WINDOW_HACK_H

--- a/src/gtk-priv-access.h
+++ b/src/gtk-priv-access.h
@@ -13,9 +13,17 @@
 #define GDK_WINDOW_HACK_H
 
 #include <gdk/gdk.h>
+#include <stdint.h>
 
 // This only has an effect the first time it's called
 // It enables gtk_window_hack_get_position () working later
 void gtk_priv_access_init (GdkWindow *gdk_window);
+
+// Returns the laster serial from a user input event
+// Can be used for popups grabs and such
+uint32_t gdk_window_get_priv_latest_serial (GdkSeat *seat);
+
+// Returns the GdkSeat that can be used for popup grabs
+GdkSeat *gdk_window_get_priv_grab_seat (GdkWindow *gdk_window);
 
 #endif // GDK_WINDOW_HACK_H


### PR DESCRIPTION
Fixes #9. About damn time. Verified to work with the oldest GTK version we claim to support (3.22.0).

__By opening this pull request, I agree for my modifications to be licensed under the same license as the files they are made to (which may be a permissive license)__
