### PR TITLE
Use system xdg-shell protocol when available

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,8 @@ gtk = dependency('gtk+-wayland-3.0', version: '>=3.22.0')
 wayland_client = dependency('wayland-client', version: '>=1.10.0')
 # wayland_scanner is required, but we can find it without pkg-config
 wayland_scanner = dependency('wayland-scanner', version: '>=1.10.0', required: false)
+# use system xdg-shell protocol when available
+wayland_protocols = dependency('wayland-protocols', version: '>=1.16', required: false)
 
 pkg_config = import('pkgconfig')
 gnome = import('gnome')

--- a/src/gtk-wayland.c
+++ b/src/gtk-wayland.c
@@ -66,7 +66,7 @@ wl_registry_handle_global (void *_data,
                                                &zwlr_layer_shell_v1_interface,
                                                MIN((uint32_t)zwlr_layer_shell_v1_interface.version, version));
     } else if (strcmp (interface, xdg_wm_base_interface.name) == 0) {
-        g_warn_if_fail (xdg_wm_base_interface.version == 2);
+        g_warn_if_fail (xdg_wm_base_interface.version >= 2);
         xdg_wm_base_global = wl_registry_bind (registry,
                                                id,
                                                &xdg_wm_base_interface,

--- a/src/protocol/meson.build
+++ b/src/protocol/meson.build
@@ -4,6 +4,15 @@ else
     prog_wayland_scanner = find_program('wayland-scanner')
 endif
 
+if wayland_protocols.found()
+    xdg_shell_proto = join_paths(
+        wayland_protocols.get_pkgconfig_variable('pkgdatadir'),
+        'stable/xdg-shell/xdg-shell.xml')
+else
+    # use bundled xdg-shell.xml from wayland-protocols-1.16
+    xdg_shell_proto = 'xdg-shell.xml'
+endif
+
 gen_client_header = generator(prog_wayland_scanner,
     output: ['@BASENAME@-client.h'],
     arguments: ['-c', 'client-header', '@INPUT@', '@BUILD_DIR@/@BASENAME@-client.h'])
@@ -13,8 +22,8 @@ gen_private_code = generator(prog_wayland_scanner,
     arguments: ['-c', 'code', '@INPUT@', '@BUILD_DIR@/@BASENAME@.c'])
 # 'code' is deprecated, and can be replaced with 'private-code' when all platforms have a new enough wayland-scanner
 
-xdg_shell_client_header = gen_client_header.process('xdg-shell.xml')
-xdg_shell_private_code = gen_private_code.process('xdg-shell.xml')
+xdg_shell_client_header = gen_client_header.process(xdg_shell_proto)
+xdg_shell_private_code = gen_private_code.process(xdg_shell_proto)
 
 layer_shell_client_header = gen_client_header.process('wlr-layer-shell-unstable-v1.xml')
 layer_shell_private_code = gen_private_code.process('wlr-layer-shell-unstable-v1.xml')


### PR DESCRIPTION
This change matters when linking as a static library or meson subproject
to the project that is already building xdg-shell protocol of a
different version. In this case linker would prefer symbols from the
main project.
If both the main project and the subproject are using the same xdg-shell
protocol definition from the system wayland-protocols, the chance of
things going wrong is slightly lesser

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
