### PR TITLE
Demo: fix initial exclusive zone and size

### DIFF
--- a/demo/gtk-layer-demo.c
+++ b/demo/gtk-layer-demo.c
@@ -313,9 +313,10 @@ layer_window_new ()
     for (int i = 0; i < GTK_LAYER_SHELL_EDGE_ENTRY_NUMBER; i++)
         gtk_layer_set_margin (gtk_window, i, default_margins[i]);
     gtk_layer_set_layer (gtk_window, default_layer);
-    gtk_layer_set_exclusive_zone (gtk_window, default_auto_exclusive_zone);
     gtk_layer_set_keyboard_interactivity (gtk_window, default_keyboard_interactivity);
     gtk_layer_set_namespace (gtk_window, "demo");
+    if (default_auto_exclusive_zone)
+        gtk_layer_auto_exclusive_zone_enable (gtk_window);
 
     GtkWidget *centered_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
     gtk_container_add (GTK_CONTAINER (gtk_window), centered_vbox);

--- a/demo/gtk-layer-demo.c
+++ b/demo/gtk-layer-demo.c
@@ -28,6 +28,8 @@ const char *prog_summary = "A GTK application for demonstrating the functionalit
 const char *prog_details = "See https://github.com/wmww/gtk-layer-shell for more information, and to report bugs";
 
 const char *anchor_edges_key = "anchor_edges";
+const int fixed_size_width = 600;
+const int fixed_size_height = 500;
 
 gboolean layer_option_callback (const gchar *option_name, const gchar *value, void *data, GError **error);
 gboolean anchor_option_callback (const gchar *option_name, const gchar *value, void *data, GError **error);
@@ -300,6 +302,9 @@ layer_window_new ()
     g_object_set_data_full (G_OBJECT (gtk_window), anchor_edges_key, data, g_free);
     for (int i = 0; i < GTK_LAYER_SHELL_EDGE_ENTRY_NUMBER; i++)
         data->edges[i] = default_anchors[i];
+
+    if (default_fixed_size)
+        gtk_widget_set_size_request (GTK_WIDGET (gtk_window), fixed_size_width, fixed_size_height);
 
     if (no_layer_shell) {
         g_message ("GTK layer shell disabled on command line");

--- a/demo/gtk-layer-demo.h
+++ b/demo/gtk-layer-demo.h
@@ -30,6 +30,8 @@ typedef struct {
 } ToplevelData;
 
 extern const char *anchor_edges_key;
+extern const int fixed_size_width;
+extern const int fixed_size_height;
 
 void
 layer_window_update_orientation (GtkWindow *layer_window);

--- a/demo/mscl-toggles.c
+++ b/demo/mscl-toggles.c
@@ -39,7 +39,7 @@ on_fixed_size_set (GtkToggleButton *_toggle_button, gboolean state, GtkWindow *l
     (void)_toggle_button;
 
     if (state) {
-        gtk_widget_set_size_request (GTK_WIDGET (layer_window), 600, 500);
+        gtk_widget_set_size_request (GTK_WIDGET (layer_window), fixed_size_width, fixed_size_height);
     } else {
         gtk_widget_set_size_request (GTK_WIDGET (layer_window), -1, -1);
     }
@@ -54,7 +54,7 @@ struct {
 } const mscl_toggles[] = {
     {"Exclusive", "Create an exclusive zone when anchored", on_exclusive_zone_state_set},
     {"Keyboard", "Get keyboard events", on_keyboard_interactivity_state_set},
-    {"Set Size", "Set a fixed window size", on_fixed_size_set},
+    {"Fixed size", "Set a fixed window size (ignored depending on anchors)", on_fixed_size_set},
 };
 
 GtkWidget *


### PR DESCRIPTION
Initial size was not being set when `--fixed-size` was specified. Exclusive zone was being set, but incorrectly. This fixes both.

Fixes #64

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
