### PR TITLE
Normalize boolean values for anchors.

### DIFF
--- a/src/layer-surface.c
+++ b/src/layer-surface.c
@@ -412,6 +412,7 @@ void
 layer_surface_set_anchor (LayerSurface *self, GtkLayerShellEdge edge, gboolean anchor_to_edge)
 {
     g_return_if_fail (edge >= 0 && edge < GTK_LAYER_SHELL_EDGE_ENTRY_NUMBER);
+    anchor_to_edge = (anchor_to_edge != FALSE);
     if (anchor_to_edge != self->anchors[edge]) {
         self->anchors[edge] = anchor_to_edge;
         if (self->layer_surface) {

--- a/test/meson.build
+++ b/test/meson.build
@@ -9,6 +9,7 @@ test_clients = [
     'test-adapts-to-screen-size',
     'test-auto-exclusive-zone-no-margin',
     'test-auto-exclusive-zone-with-margin',
+    'test-auto-exclusive-zone-weird-bool-values',
     'test-menu-popup',
 ]
 

--- a/test/test-clients/test-auto-exclusive-zone-weird-bool-values.c
+++ b/test/test-clients/test-auto-exclusive-zone-weird-bool-values.c
@@ -1,0 +1,37 @@
+/* This entire file is licensed under MIT
+ *
+ * Copyright 2020 William Wold
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "test-client-common.h"
+
+static GtkWindow* window;
+
+static void callback_0()
+{
+    EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_exclusive_zone 300);
+
+    window = create_default_window();
+
+    gtk_layer_init_for_window(window);
+    gtk_layer_auto_exclusive_zone_enable(window);
+
+    // Note that true bools are normally 1, but can be other non-zero values
+    // This used to cause a problem, as noted in https://github.com/wmww/gtk-layer-shell/pull/79
+    gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_BOTTOM, 1);
+    gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_TOP, 2);
+    gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_LEFT, 3);
+
+    gtk_widget_set_size_request(GTK_WIDGET(window), 300, 200);
+    gtk_widget_show_all(GTK_WIDGET(window));
+}
+
+TEST_CALLBACKS(
+    callback_0,
+)


### PR DESCRIPTION
The code in this file assumes that all true gbooleans are equal. That's
not correct and it's acceptable, albeit discouraged, to assign any int
value to gboolean. Of course in this case any strict equality checks in
this file could fail.

Fixes auto exclusive zone when passing values other than TRUE or FALSE
to `gtk_layer_set_anchor`.
***
For reference, this is how waybar code looked before I finally decided to figure out why auto exclusive zone doesn't work.
```c++
  gtk_layer_set_anchor(
      gtk_window, GTK_LAYER_SHELL_EDGE_LEFT, anchor_ & ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT);
  gtk_layer_set_anchor(
      gtk_window, GTK_LAYER_SHELL_EDGE_RIGHT, anchor_ & ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
  gtk_layer_set_anchor(
      gtk_window, GTK_LAYER_SHELL_EDGE_TOP, anchor_ & ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP);
  gtk_layer_set_anchor(
      gtk_window, GTK_LAYER_SHELL_EDGE_BOTTOM, anchor_ & ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM);
```

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
