### PR TITLE
Add monitor tests

### DIFF
--- a/test/integration-tests/meson.build
+++ b/test/integration-tests/meson.build
@@ -24,4 +24,6 @@ integration_tests = [
     'test-get-namespace-custom-namespace',
     'test-set-keyboard-interactivity',
     'test-get-keyboard-interactivity',
+    'test-get-monitor',
+    'test-set-monitor',
 ]

--- a/test/integration-tests/test-get-monitor.c
+++ b/test/integration-tests/test-get-monitor.c
@@ -1,0 +1,34 @@
+/* This entire file is licensed under MIT
+ *
+ * Copyright 2020 William Wold
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "integration-test-common.h"
+
+static GtkWindow* window;
+
+static void callback_0()
+{
+    window = create_default_window();
+    gtk_layer_init_for_window(window);
+    ASSERT_EQ(gdk_display_get_n_monitors(gdk_display_get_default()), 1, "%d");
+    GdkMonitor *monitor = gdk_display_get_monitor(gdk_display_get_default(), 0);
+    ASSERT(GDK_IS_MONITOR(monitor));
+    ASSERT_EQ(gtk_layer_get_monitor(window), NULL, "%p");
+    gtk_layer_set_monitor(window, monitor);
+    ASSERT_EQ(gtk_layer_get_monitor(window), monitor, "%p");
+    gtk_widget_show_all(GTK_WIDGET(window));
+    ASSERT_EQ(gtk_layer_get_monitor(window), monitor, "%p");
+    gtk_layer_set_monitor(window, NULL);
+    ASSERT_EQ(gtk_layer_get_monitor(window), NULL, "%p");
+}
+
+TEST_CALLBACKS(
+    callback_0,
+)

--- a/test/integration-tests/test-set-monitor.c
+++ b/test/integration-tests/test-set-monitor.c
@@ -1,0 +1,37 @@
+/* This entire file is licensed under MIT
+ *
+ * Copyright 2020 William Wold
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "integration-test-common.h"
+
+static GtkWindow* window;
+
+static void callback_0()
+{
+    EXPECT_MESSAGE(zwlr_layer_shell_v1 .get_layer_surface wl_output@);
+    window = create_default_window();
+    gtk_layer_init_for_window(window);
+    ASSERT_EQ(gdk_display_get_n_monitors(gdk_display_get_default()), 1, "%d");
+    GdkMonitor *monitor = gdk_display_get_monitor(gdk_display_get_default(), 0);
+    ASSERT(GDK_IS_MONITOR(monitor));
+    gtk_layer_set_monitor(window, monitor);
+    gtk_widget_show_all(GTK_WIDGET(window));
+}
+
+static void callback_1()
+{
+    EXPECT_MESSAGE(zwlr_layer_shell_v1 .get_layer_surface nil);
+    gtk_layer_set_monitor(window, NULL);
+}
+
+TEST_CALLBACKS(
+    callback_0,
+    callback_1,
+)

--- a/test/mock-server/overrides.c
+++ b/test/mock-server/overrides.c
@@ -40,6 +40,7 @@ typedef struct
 
 static struct wl_resource* seat_global = NULL;
 static struct wl_resource* pointer_global = NULL;
+static struct wl_resource* output_global = NULL;
 static uint32_t click_serial = 0;
 
 // Needs to be called before any role objects are asigned
@@ -156,6 +157,14 @@ void wl_seat_bind(struct wl_client* client, void* data, uint32_t version, uint32
     seat_global = wl_resource_create(client, &wl_seat_interface, version, id);
     use_default_impl(seat_global);
     wl_seat_send_capabilities(seat_global, WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_KEYBOARD);
+};
+
+void wl_output_bind(struct wl_client* client, void* data, uint32_t version, uint32_t id)
+{
+    ASSERT(!output_global);
+    output_global = wl_resource_create(client, &wl_output_interface, version, id);
+    use_default_impl(output_global);
+    wl_output_send_done(output_global);
 };
 
 static void wl_seat_get_pointer(struct wl_resource *resource, const struct wl_message* message, union wl_argument* args)
@@ -314,8 +323,8 @@ void init()
     OVERRIDE_REQUEST(zwlr_layer_surface_v1, destroy);
 
     wl_global_create(display, &wl_seat_interface, 6, NULL, wl_seat_bind);
+    wl_global_create(display, &wl_output_interface, 2, NULL, wl_output_bind);
     default_global_create(display, &wl_shm_interface, 1);
-    default_global_create(display, &wl_output_interface, 2);
     default_global_create(display, &wl_data_device_manager_interface, 2);
     default_global_create(display, &wl_compositor_interface, 4);
     default_global_create(display, &xdg_wm_base_interface, 2);


### PR DESCRIPTION
This works locally on Ubuntu 20.04 with GTK v3.22.0 and GTK v3.24.20. It fails in CI for unknown reasons.

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
