### PR TITLE
Set layer surfaces to mapped

### DIFF
--- a/src/custom-shell-surface.c
+++ b/src/custom-shell-surface.c
@@ -62,6 +62,7 @@ custom_shell_surface_on_window_map (GtkWidget *widget, CustomShellSurface *self)
     wl_surface_attach (wl_surface, NULL, 0, 0);
 
     self->virtual->map (self, wl_surface);
+    gdk_window_set_priv_mapped (gdk_window);
 
     wl_surface_commit (wl_surface);
     wl_display_roundtrip (gdk_wayland_display_get_wl_display (gdk_display_get_default ()));

--- a/src/gtk-priv-access.c
+++ b/src/gtk-priv-access.c
@@ -169,6 +169,13 @@ gdk_window_move_to_rect_impl_override (GdkWindow *window,
 }
 
 void
+gdk_window_set_priv_mapped (GdkWindow *gdk_window)
+{
+    GdkWindowImplWayland *window_impl = (GdkWindowImplWayland *)gdk_window_priv_get_impl (gdk_window);
+    gdk_window_impl_wayland_priv_set_mapped (window_impl, TRUE);
+}
+
+void
 gtk_priv_access_init (GdkWindow *gdk_window)
 {
     // Don't do anything once this has run successfully once

--- a/src/gtk-priv-access.h
+++ b/src/gtk-priv-access.h
@@ -26,4 +26,8 @@ uint32_t gdk_window_get_priv_latest_serial (GdkSeat *seat);
 // Returns the GdkSeat that can be used for popup grabs
 GdkSeat *gdk_window_get_priv_grab_seat (GdkWindow *gdk_window);
 
+// Sets the window as mapped (mapped is set to false automatically in gdk_wayland_window_hide_surface ())
+// If window is not set to mapped, some subsurfaces fail (see https://github.com/wmww/gtk-layer-shell/issues/38)
+void gdk_window_set_priv_mapped (GdkWindow *gdk_window);
+
 #endif // GDK_WINDOW_HACK_H

--- a/test/integration-tests/meson.build
+++ b/test/integration-tests/meson.build
@@ -26,4 +26,5 @@ integration_tests = [
     'test-get-keyboard-interactivity',
     'test-get-monitor',
     'test-set-monitor',
+    'test-create-subsurface',
 ]

--- a/test/integration-tests/test-create-subsurface.c
+++ b/test/integration-tests/test-create-subsurface.c
@@ -1,0 +1,37 @@
+/* This entire file is licensed under MIT
+ *
+ * Copyright 2020 William Wold
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "integration-test-common.h"
+
+static GtkWindow* window;
+static GtkWindow* subsurface;
+
+static void callback_0()
+{
+    EXPECT_MESSAGE(wl_subcompositor .get_subsurface);
+    EXPECT_MESSAGE(wl_subsurface .set_position -20 30);
+
+    window = create_default_window();
+    gtk_layer_init_for_window(window);
+
+    subsurface = GTK_WINDOW(gtk_window_new(GTK_WINDOW_POPUP));
+    gtk_container_add(GTK_CONTAINER(subsurface), gtk_label_new("Subsurface"));
+    gtk_window_set_modal(subsurface, TRUE);
+    gtk_window_set_transient_for(subsurface, window);
+    gtk_window_move(subsurface, -20, 30);
+
+    gtk_widget_show_all(GTK_WIDGET(window));
+    gtk_widget_show_all(GTK_WIDGET(subsurface));
+}
+
+TEST_CALLBACKS(
+    callback_0,
+)

--- a/test/mock-server/overrides.c
+++ b/test/mock-server/overrides.c
@@ -331,6 +331,7 @@ void init()
     default_global_create(display, &wl_shm_interface, 1);
     default_global_create(display, &wl_data_device_manager_interface, 2);
     default_global_create(display, &wl_compositor_interface, 4);
+    default_global_create(display, &wl_subcompositor_interface, 1);
     default_global_create(display, &xdg_wm_base_interface, 2);
     default_global_create(display, &zwlr_layer_shell_v1_interface, 3);
 }


### PR DESCRIPTION
This fixes #38 with no known unwanted side-effects. `mapped` isn't supposed to be set for custom surfaces, but I dug through all the code that uses it without spotting anything that might cause a problem. This also adds a test for #38.

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
