### PR TITLE
build: Make generating introspection data optional

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('examples', type: 'boolean', value: false, description: 'Build example applications')
 option('docs', type: 'boolean', value: false, description: 'Build devhelp API documentation')
+option('introspection', type: 'boolean', value: true, description: 'Build GObject introspection data')
 option('tests', type: 'boolean', value: false, description: 'Build tests')

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,18 +26,23 @@ gtk_layer_shell_lib = library('gtk-layer-shell',
 pkg_config_name = 'gtk-layer-shell-0'
 
 # GObject introspection file used to interface with other languages
-gir = gnome.generate_gir(
-    gtk_layer_shell_lib,
-    dependencies: [gtk],
-    sources: srcs + files('../include/gtk-layer-shell.h'),
-    namespace: 'GtkLayerShell',
-    nsversion: '0.1',
-    identifier_prefix: 'GtkLayerShell',
-    symbol_prefix: 'gtk_layer',
-    export_packages: pkg_config_name,
-    includes: [ 'Gtk-3.0' ],
-    header: 'gtk-layer-shell/gtk-layer-shell.h',
-    install: true)
+gir = find_program('g-ir-scanner', required: get_option('introspection'))
+build_gir = gir.found() and get_option('introspection')
+
+if build_gir
+    gir = gnome.generate_gir(
+        gtk_layer_shell_lib,
+        dependencies: [gtk],
+        sources: srcs + files('../include/gtk-layer-shell.h'),
+        namespace: 'GtkLayerShell',
+        nsversion: '0.1',
+        identifier_prefix: 'GtkLayerShell',
+        symbol_prefix: 'gtk_layer',
+        export_packages: pkg_config_name,
+        includes: [ 'Gtk-3.0' ],
+        header: 'gtk-layer-shell/gtk-layer-shell.h',
+        install: true)
+endif
 
 pkg_config.generate(
     name: 'gtk-layer-shell',


### PR DESCRIPTION
This allows source-based distributions to avoid having to build gtk and
all it's dependencies with introspection support.
Also cross-compilation is tricky when GI is involved, so this way one
can cross-compile the project easily by just disabling the introspection
data (it's enabled by default, so the behaviour isn't changed)

Replace this paragraph with your normal PR comment. Do NOT remove the agreement below. It simply means if you changed an MIT licensed file, the entire file remains MIT.

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
