### PR TITLE
meson: Allow disabling gobject-introspection at build time

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('examples', type: 'boolean', value: false, description: 'Build example applications')
 option('docs', type: 'boolean', value: false, description: 'Build devhelp API documentation')
 option('tests', type: 'boolean', value: false, description: 'Build tests')
+option('introspection', type: 'boolean', value: true, description: 'Build gobject-introspection data')

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,18 +26,20 @@ gtk_layer_shell_lib = library('gtk-layer-shell',
 pkg_config_name = 'gtk-layer-shell-0'
 
 # GObject introspection file used to interface with other languages
-gir = gnome.generate_gir(
-    gtk_layer_shell_lib,
-    dependencies: [gtk],
-    sources: srcs + files('../include/gtk-layer-shell.h'),
-    namespace: 'GtkLayerShell',
-    nsversion: '0.1',
-    identifier_prefix: 'GtkLayerShell',
-    symbol_prefix: 'gtk_layer',
-    export_packages: pkg_config_name,
-    includes: [ 'Gtk-3.0' ],
-    header: 'gtk-layer-shell/gtk-layer-shell.h',
-    install: true)
+if get_option('introspection')
+    gir = gnome.generate_gir(
+        gtk_layer_shell_lib,
+        dependencies: [gtk],
+        sources: srcs + files('../include/gtk-layer-shell.h'),
+        namespace: 'GtkLayerShell',
+        nsversion: '0.1',
+        identifier_prefix: 'GtkLayerShell',
+        symbol_prefix: 'gtk_layer',
+        export_packages: pkg_config_name,
+        includes: [ 'Gtk-3.0' ],
+        header: 'gtk-layer-shell/gtk-layer-shell.h',
+        install: true)
+endif
 
 pkg_config.generate(
     name: 'gtk-layer-shell',


### PR DESCRIPTION
Add an `introspection` option to the Meson build system which allows toggling generation of GObject-Introspection data. This can be useful for systems where G-I is not needed or not used.

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
