### PR TITLE
Fix documentation to refer to variants

### DIFF
--- a/include/gtk-layer-shell.h
+++ b/include/gtk-layer-shell.h
@@ -206,7 +206,7 @@ const char *gtk_layer_get_namespace (GtkWindow *window);
  * be changed on-the-fly in the current version of the layer shell protocol, but on compositors that only support an
  * older version the @window is remapped so the change can take effect.
  *
- * Default is #GTK_LAYER_SHELL_LAYER_TOP
+ * Default is %GTK_LAYER_SHELL_LAYER_TOP
  */
 void gtk_layer_set_layer (GtkWindow *window, GtkLayerShellLayer layer);
 
@@ -347,7 +347,7 @@ gboolean gtk_layer_auto_exclusive_zone_is_enabled (GtkWindow *window);
  * Sets if/when @window should receive keyboard events from the compositor, see
  * GtkLayerShellKeyboardMode for details.
  *
- * Default is #GTK_LAYER_SHELL_KEYBOARD_MODE_NONE
+ * Default is %GTK_LAYER_SHELL_KEYBOARD_MODE_NONE
  *
  * Since: 0.6
  */


### PR DESCRIPTION
Thank you for writing gtk-layer-shell!
I am updating and cleaning the Rust wrapper, which I automatically created using gir. I now added documentation but when I generate it, I get two warnings described in [issue 2](https://github.com/pentamassiv/gtk-layer-shell-gir/issues/2) of the repo.

I suggest to use % instead of # in the docs to show that it is a reference to a variant of an enum and not it's own type. This gets rid of the warning and at least the Rust docs don't seem to change from it. If I read [this comment](https://github.com/gtk-rs/gir/pull/1085#discussion_r603837736) correctly, the warning and the proposed changes make sense.

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
