### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A library to write [GTK](https://www.gtk.org/) applications that use [Layer Shell](https://github.com/swaywm/wlr-protocols/blob/master/unstable/wlr-layer-shell-unstable-v1.xml). Layer Shell is a Wayland protocol for desktop shell components, such as panels, notifications and wallpapers. You can use it to anchor your windows to a corner or edge of the output, or stretch them across the entire output. It supports all Layer Shell features including popups and popovers (GTK popups Just Work™). This Library is compatible with C, C++ and any language that supports GObject introspection files (Python, Vala, etc, see using the library below).
 
 ## Supported Desktops
-This library only works on Wayland, and only on Wayland compositors that support the Layer Shell protcol. Layer shell __is supported__ on:
+This library only works on Wayland, and only on Wayland compositors that support the Layer Shell protocol. Layer shell __is supported__ on:
 - wlroots based compositors (such as __Sway__)
 - Mir-based compositors (some may not enable the protocol by default and require `--add-wayland-extension zwlr_layer_shell_v1`)
 
@@ -57,7 +57,7 @@ sudo apt install meson libwayland-dev libgtk-3-dev gobject-introspection libgire
 * `-Dexamples` (default `false`): If to build the example C apps; gtk-layer-demo is installed if examples are built; The Vala example is never built with the rest of the project
 * `-Ddocs` (default `false`): If to generate the docs
 * `-Dtests` (default `false`): If to build the tests
-* `-Dintrospection` (default: `true`): If to build GObject Introspection data (used for bindings to langauges other than C/C++)
+* `-Dintrospection` (default: `true`): If to build GObject Introspection data (used for bindings to languages other than C/C++)
 * `-Dvapi` (default: `true`): If to build VAPI data (allows this library to be used in Vala). Requires `-Dintrospection=true`
 
 ### Running the Tests

--- a/examples/simple-example.c
+++ b/examples/simple-example.c
@@ -29,7 +29,7 @@ activate (GtkApplication* app, void *_data)
     // Push other windows out of the way
     gtk_layer_auto_exclusive_zone_enable (gtk_window);
 
-    // We don't need to get keybard input
+    // We don't need to get keyboard input
     // gtk_layer_set_keyboard_mode (gtk_window, GTK_LAYER_SHELL_KEYBOARD_MODE_NONE); // NONE is default
 
     // The margins are the gaps around the window's edges

--- a/include/gtk-layer-shell.h
+++ b/include/gtk-layer-shell.h
@@ -175,7 +175,7 @@ struct zwlr_layer_surface_v1 *gtk_layer_get_zwlr_layer_surface_v1 (GtkWindow *wi
  * Set the "namespace" of the surface.
  *
  * No one is quite sure what this is for, but it probably should be something generic
- * ("panel", "osk", etc). The @name_space string is copied, and caller maintians
+ * ("panel", "osk", etc). The @name_space string is copied, and caller maintains
  * ownership of original. If the window is currently mapped, it will get remapped so
  * the change can take effect.
  *
@@ -248,7 +248,7 @@ GdkMonitor *gtk_layer_get_monitor (GtkWindow *window);
 /**
  * gtk_layer_set_anchor:
  * @window: A layer surface.
- * @edge: A #GtkLayerShellEdge this layer suface may be anchored to.
+ * @edge: A #GtkLayerShellEdge this layer surface may be anchored to.
  * @anchor_to_edge: Whether or not to anchor this layer surface to @edge.
  *
  * Set whether @window should be anchored to @edge.
@@ -380,7 +380,7 @@ void gtk_layer_set_keyboard_interactivity (GtkWindow *window, gboolean interacti
  * gtk_layer_get_keyboard_interactivity:
  * @window: A layer surface.
  *
- * Returns: if keybaord interactivity is enabled
+ * Returns: if keyboard interactivity is enabled
  *
  * Since: 0.5
  * Deprecated: 0.6: Use gtk_layer_get_keyboard_mode () instead.

--- a/src/custom-shell-surface.c
+++ b/src/custom-shell-surface.c
@@ -57,7 +57,7 @@ custom_shell_surface_on_window_map (GtkWidget *widget, CustomShellSurface *self)
 
     // In some cases (observed when a mate panel has an image background) GDK will attach a buffer just after creating
     // the surface (see the implementation of gdk_wayland_window_show() for details). Giving the surface a role with a
-    // buffer attached is a protocol violation, so we attach a null buffer. GDK hasn't commited the buffer it may have
+    // buffer attached is a protocol violation, so we attach a null buffer. GDK hasn't committed the buffer it may have
     // attached, so we don't need to commit. If this is removed, test-window-with-initially-attached-buffer should fail.
     wl_surface_attach (wl_surface, NULL, 0, 0);
 

--- a/src/layer-surface.c
+++ b/src/layer-surface.c
@@ -60,7 +60,7 @@ layer_surface_send_set_size (LayerSurface *self)
  * Sets the window's geometry hints (used to force the window to be a specific size)
  * Needs to be called whenever last_configure_size or anchors are changed
  * Lets windows decide their own size along any axis the surface is not stretched along
- * Forces window (by setting the max and min hints) to be of configured size along axises they are stretched along
+ * Forces window (by setting the max and min hints) to be of configured size along axes they are stretched along
  */
 static void
 layer_surface_update_size (LayerSurface *self)

--- a/test/README.md
+++ b/test/README.md
@@ -9,7 +9,7 @@ This directory is home to the gtk-layer-shell test suite.
 2. Implement your test as a series of one or more callbacks
 3. Add its name to the list in `test/integration-tests/meson.build`
 
-## Scrpts
+## Scripts
 - `check-licenses.py` makes sure all files have licenses at the top
 - `tests-not-enabled.py` is only run if tests are disabled, and explains to the user how to enable them
 - `run-integration-test.py` runs a single integration test

--- a/test/check-licenses.py
+++ b/test/check-licenses.py
@@ -11,7 +11,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 '''
 
-# This script checks that every soruce file in the project has an appropriate license
+# This script checks that every source file in the project has an appropriate license
 
 import logging
 import re

--- a/test/integration-test-common/integration-test-common.c
+++ b/test/integration-test-common/integration-test-common.c
@@ -11,7 +11,7 @@
 
 #include "integration-test-common.h"
 
-// Time in miliseconds for each callback to run
+// Time in milliseconds for each callback to run
 static int step_time = 300;
 
 static int return_code = 0;

--- a/test/integration-test-common/integration-test-common.h
+++ b/test/integration-test-common/integration-test-common.h
@@ -21,11 +21,11 @@
 
 // Tell the test script that a request containing the given space-separated components is expected
 #define EXPECT_MESSAGE(message) fprintf(stderr, "EXPECT: %s\n", #message)
-// Tell the test script that all expected messages should now be fufilled
+// Tell the test script that all expected messages should now be fulfilled
 // (called automatically before each callback and at the end of the test)
 #define CHECK_EXPECTATIONS() fprintf(stderr, "CHECK EXPECTATIONS COMPLETED\n")
 
-// NULL-terminated list of callbacks that will be called before quiting
+// NULL-terminated list of callbacks that will be called before quitting
 // Should be defined in the test file using TEST_CALLBACKS()
 extern void (* test_callbacks[])(void);
 

--- a/test/mock-server/overrides.c
+++ b/test/mock-server/overrides.c
@@ -43,7 +43,7 @@ static struct wl_resource* pointer_global = NULL;
 static struct wl_resource* output_global = NULL;
 static uint32_t click_serial = 0;
 
-// Needs to be called before any role objects are asigned
+// Needs to be called before any role objects are assigned
 static void surface_data_set_role(SurfaceData* data, SurfaceRole role)
 {
     ASSERT_EQ(data->role, SURFACE_ROLE_NONE, "%u");


### PR DESCRIPTION
Found via `codespell -L crate,gir`

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
