### PR TITLE
Remove redundant dependency check for gtk-doc

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -4,8 +4,6 @@ glib_prefix = dependency('glib-2.0').get_pkgconfig_variable('prefix')
 glib_docpath = join_paths(glib_prefix, 'share', 'gtk-doc', 'html')
 docpath = join_paths(get_option('datadir'), 'gtk-doc', 'html')
 
-gtk_doc_dep = dependency('gtk-doc')
-
 gnome.gtkdoc(
     'gtk-layer-shell',
     main_xml: 'gtk-layer-shell-docs.sgml',


### PR DESCRIPTION
This was introduced in https://github.com/wmww/gtk-layer-shell/pull/28
Pointed out by @Artturin in https://github.com/NixOS/nixpkgs/pull/211502#discussion_r1096323072

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
