### PR TITLE
Fix deprecation warning when running meson

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The easiest way to build against GTK Layer Shell is to use the `gtk-layer-shell-
 ## Building From Source
 1. Clone this repo
 2. Install build dependencies (see below)
-3. `$ meson build -Dexamples=true -Ddocs=true -Dtests=true`
+3. `$ meson setup -Dexamples=true -Ddocs=true -Dtests=true build`
 4. `$ ninja -C build`
 5. `$ sudo ninja -C build install`
 6. `$ sudo ldconfig`


### PR DESCRIPTION
If the commands from the README.md are followed, the following deprecation warning is displayed when running meson:
```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```
This small change gets rid of it.

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*