### PR TITLE
Use gtk-priv to get window geometry

### DIFF
--- a/src/custom-shell-surface.c
+++ b/src/custom-shell-surface.c
@@ -108,14 +108,6 @@ custom_shell_surface_get_gtk_window (CustomShellSurface *self)
 }
 
 void
-custom_shell_surface_get_window_geom (CustomShellSurface *self, GdkRectangle *geom)
-{
-    g_return_if_fail (self);
-    // TODO: Store the actual window geometry used
-    *geom = gtk_wayland_get_logical_geom (self->private->gtk_window);
-}
-
-void
 custom_shell_surface_needs_commit (CustomShellSurface *self)
 {
     if (!self->private->gtk_window)

--- a/src/gtk-priv-access.c
+++ b/src/gtk-priv-access.c
@@ -191,3 +191,20 @@ gtk_priv_access_init (GdkWindow *gdk_window)
         gdk_window_impl_class_priv_set_move_to_rect (window_class, gdk_window_move_to_rect_impl_override);
     }
 }
+
+GdkRectangle
+gtk_window_get_priv_logical_geom (GtkWindow *gtk_window)
+{
+    GdkWindow *gdk_window = gtk_widget_get_window (GTK_WIDGET (gtk_window));
+    GdkWindowImplWayland *window_impl = (GdkWindowImplWayland *)gdk_window_priv_get_impl (gdk_window);
+    GdkRectangle result;
+    result.x = gdk_window_impl_wayland_priv_get_margin_left (window_impl);
+    result.y = gdk_window_impl_wayland_priv_get_margin_top (window_impl);
+    result.width = gdk_window_get_width (gdk_window) -
+        gdk_window_impl_wayland_priv_get_margin_left (window_impl) -
+        gdk_window_impl_wayland_priv_get_margin_right (window_impl);
+    result.height = gdk_window_get_height (gdk_window) -
+        gdk_window_impl_wayland_priv_get_margin_top (window_impl) -
+        gdk_window_impl_wayland_priv_get_margin_bottom (window_impl);
+    return result;
+}

--- a/src/gtk-priv-access.h
+++ b/src/gtk-priv-access.h
@@ -13,6 +13,7 @@
 #define GDK_WINDOW_HACK_H
 
 #include <gdk/gdk.h>
+#include <gtk/gtk.h>
 #include <stdint.h>
 
 // This only has an effect the first time it's called
@@ -29,5 +30,8 @@ GdkSeat *gdk_window_get_priv_grab_seat (GdkWindow *gdk_window);
 // Sets the window as mapped (mapped is set to false automatically in gdk_wayland_window_hide_surface ())
 // If window is not set to mapped, some subsurfaces fail (see https://github.com/wmww/gtk-layer-shell/issues/38)
 void gdk_window_set_priv_mapped (GdkWindow *gdk_window);
+
+// Gets the window geometry (area inside the window that excludes the shadow)
+GdkRectangle gtk_window_get_priv_logical_geom (GtkWindow *widget);
 
 #endif // GDK_WINDOW_HACK_H

--- a/src/gtk-wayland.c
+++ b/src/gtk-wayland.c
@@ -200,18 +200,3 @@ gtk_wayland_setup_window_as_custom_popup (GdkWindow *gdk_window, XdgPopupPositio
         g_object_set_data_full (G_OBJECT (gdk_window), popup_position_key, position_owned, g_free);
     }
 }
-
-// Gets the upper left and size of the portion of the window that is actually used (not shadows and whatnot)
-// It does this by walking down the gdk_window tree, as long as there is exactly one child
-GdkRectangle
-gtk_wayland_get_logical_geom (GtkWindow *gtk_window)
-{
-    GdkWindow *window = gtk_widget_get_window (GTK_WIDGET (gtk_window));
-    GList *list = gdk_window_get_children (window);
-    if (list && !list->next) // If there is exactly one child window
-        window = list->data;
-    g_list_free(list);
-    GdkRectangle geom;
-    gdk_window_get_geometry (window, &geom.x, &geom.y, &geom.width, &geom.height);
-    return geom;
-}

--- a/src/gtk-wayland.h
+++ b/src/gtk-wayland.h
@@ -28,6 +28,4 @@ GtkWindow *gtk_wayland_gdk_to_gtk_window (GdkWindow *gdk_window);
 // Does not take ownership of position
 void gtk_wayland_setup_window_as_custom_popup (GdkWindow *gdk_window, XdgPopupPosition const *position);
 
-GdkRectangle gtk_wayland_get_logical_geom (GtkWindow *widget);
-
 #endif // WAYLAND_GLOBALS_H

--- a/src/xdg-popup-surface.c
+++ b/src/xdg-popup-surface.c
@@ -161,7 +161,7 @@ xdg_popup_surface_map (CustomShellSurface *super, struct wl_surface *wl_surface)
     struct xdg_wm_base *xdg_wm_base_global = gtk_wayland_get_xdg_wm_base_global ();
     g_return_if_fail (xdg_wm_base_global);
     struct xdg_positioner *positioner = xdg_wm_base_create_positioner (xdg_wm_base_global);
-    self->geom = gtk_wayland_get_logical_geom (gtk_window);
+    self->geom = gtk_window_get_priv_logical_geom (gtk_window);
     enum xdg_positioner_anchor anchor = gdk_gravity_get_xdg_positioner_anchor(self->position.rect_anchor);
     enum xdg_positioner_gravity gravity = gdk_gravity_get_xdg_positioner_gravity(self->position.window_anchor);
     enum xdg_positioner_constraint_adjustment constraint_adjustment =
@@ -257,7 +257,7 @@ xdg_popup_surface_on_size_allocate (GtkWidget *_widget,
         self->cached_allocation = *allocation;
         // allocation only used for catching duplicate calls. To get the correct geom we need to check something else
         GtkWindow *gtk_window = custom_shell_surface_get_gtk_window ((CustomShellSurface *)self);
-        self->geom = gtk_wayland_get_logical_geom (gtk_window);
+        self->geom = gtk_window_get_priv_logical_geom (gtk_window);
         xdg_surface_set_window_geometry (self->xdg_surface,
                                          self->geom.x,
                                          self->geom.y,

--- a/src/xdg-toplevel-surface.c
+++ b/src/xdg-toplevel-surface.c
@@ -14,6 +14,7 @@
 #include "custom-shell-surface.h"
 #include "gtk-wayland.h"
 #include "simple-conversions.h"
+#include "gtk-priv-access.h"
 
 #include "xdg-shell-client.h"
 
@@ -106,7 +107,7 @@ xdg_toplevel_surface_map (CustomShellSurface *super, struct wl_surface *wl_surfa
     xdg_toplevel_set_title (self->xdg_toplevel, name);
 
     GtkWindow *gtk_window = custom_shell_surface_get_gtk_window (super);
-    self->geom = gtk_wayland_get_logical_geom (gtk_window);
+    self->geom = gtk_window_get_priv_logical_geom (gtk_window);
     xdg_surface_set_window_geometry (self->xdg_surface,
                                      self->geom.x,
                                      self->geom.y,
@@ -178,7 +179,7 @@ xdg_toplevel_surface_on_size_allocate (GtkWidget *_widget,
         self->cached_allocation = *allocation;
         // allocation only used for catching duplicate calls. To get the correct geom we need to check something else
         GtkWindow *gtk_window = custom_shell_surface_get_gtk_window ((CustomShellSurface *)self);
-        self->geom = gtk_wayland_get_logical_geom (gtk_window);
+        self->geom = gtk_window_get_priv_logical_geom (gtk_window);
         xdg_surface_set_window_geometry (self->xdg_surface,
                                          self->geom.x,
                                          self->geom.y,


### PR DESCRIPTION
Fixes #163. Replaces a messy (and broken) hack for getting window geometry. We have gtk-priv now, use it. 

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
