### PR TITLE
Use widget's preferred size by default

### DIFF
--- a/src/layer-surface.c
+++ b/src/layer-surface.c
@@ -67,25 +67,25 @@ layer_surface_update_size (LayerSurface *self)
 {
     GtkWindow *gtk_window = custom_shell_surface_get_gtk_window ((CustomShellSurface *)self);
 
-    gint width = -1;
-    gint height = -1;
+    GtkRequisition size;
+    gtk_widget_get_preferred_size (GTK_WIDGET (gtk_window), NULL, &size);
 
     if ((self->anchors[GTK_LAYER_SHELL_EDGE_LEFT]) &&
         (self->anchors[GTK_LAYER_SHELL_EDGE_RIGHT])) {
 
-        width = self->last_configure_size.width;
+        size.width = self->last_configure_size.width;
     }
     if ((self->anchors[GTK_LAYER_SHELL_EDGE_TOP]) &&
         (self->anchors[GTK_LAYER_SHELL_EDGE_BOTTOM])) {
 
-        height = self->last_configure_size.height;
+        size.height = self->last_configure_size.height;
     }
 
     GdkGeometry hints;
-    hints.min_width = width;
-    hints.max_width = width;
-    hints.min_height = height;
-    hints.max_height = height;
+    hints.min_width = size.width;
+    hints.max_width = size.width;
+    hints.min_height = size.height;
+    hints.max_height = size.height;
 
     gtk_window_set_geometry_hints (gtk_window,
                                    NULL,

--- a/test/integration-tests/meson.build
+++ b/test/integration-tests/meson.build
@@ -9,6 +9,8 @@ integration_tests = [
     'test-set-layer',
     'test-get-layer',
     'test-set-size-request',
+    'test-size-can-shrink',
+    'test-appears-if-size-initially-unspecified',
     'test-adapts-to-screen-size',
     'test-auto-exclusive-zone-no-margin',
     'test-auto-exclusive-zone-with-margin',

--- a/test/integration-tests/test-appears-if-size-initially-unspecified.c
+++ b/test/integration-tests/test-appears-if-size-initially-unspecified.c
@@ -1,0 +1,38 @@
+/* This entire file is licensed under MIT
+ *
+ * Copyright 2020 Sophie Winter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "integration-test-common.h"
+
+static GtkWindow* window;
+static GtkWidget* child;
+
+static void callback_0()
+{
+    window = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
+    child = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    gtk_container_add(GTK_CONTAINER(window), child);
+
+    gtk_layer_init_for_window(window);
+    gtk_widget_show_all(GTK_WIDGET(window));
+}
+
+static void callback_1()
+{
+    EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 400 300);
+
+    gtk_widget_set_size_request(GTK_WIDGET(window), 400, 300);
+    gtk_window_resize(window, 1, 1);
+}
+
+TEST_CALLBACKS(
+    callback_0,
+    callback_1,
+)

--- a/test/integration-tests/test-size-can-shrink.c
+++ b/test/integration-tests/test-size-can-shrink.c
@@ -1,0 +1,51 @@
+/* This entire file is licensed under MIT
+ *
+ * Copyright 2020 Sophie Winter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "integration-test-common.h"
+
+static GtkWindow* window;
+static GtkWidget* child;
+
+static void callback_0()
+{
+    EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 600 500);
+
+    window = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
+    child = gtk_label_new("foo");
+    gtk_container_add(GTK_CONTAINER(window), child);
+
+    gtk_layer_init_for_window(window);
+    gtk_widget_set_size_request(GTK_WIDGET(window), 600, 500);
+    gtk_widget_show_all(GTK_WIDGET(window));
+}
+
+static void callback_1()
+{
+    EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 500 400);
+
+    gtk_widget_set_size_request(GTK_WIDGET(window), 500, 400);
+    gtk_window_resize(window, 1, 1);
+}
+
+static void callback_2()
+{
+    EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 400 300);
+
+    gtk_widget_set_size_request(GTK_WIDGET(window), -1, -1);
+    gtk_widget_set_size_request(child, 400, 300);
+    gtk_window_resize(window, 1, 1);
+}
+
+TEST_CALLBACKS(
+    callback_0,
+    callback_1,
+    callback_2,
+)


### PR DESCRIPTION
The old behavior caused Flutter windows to have zero size and not show up unless they explicitly requested a size.

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
