### PR TITLE
Make tests compatible with new libwayland format

### DIFF
--- a/test/integration-tests/test-set-monitor.c
+++ b/test/integration-tests/test-set-monitor.c
@@ -15,7 +15,7 @@ static GtkWindow* window;
 
 static void callback_0()
 {
-    EXPECT_MESSAGE(zwlr_layer_shell_v1 .get_layer_surface wl_output@);
+    EXPECT_MESSAGE(zwlr_layer_shell_v1 .get_layer_surface wl_output);
     window = create_default_window();
     gtk_layer_init_for_window(window);
     ASSERT_EQ(gdk_display_get_n_monitors(gdk_display_get_default()), 1, "%d");

--- a/test/run-integration-test.py
+++ b/test/run-integration-test.py
@@ -218,7 +218,7 @@ def verify_result(lines: List[str]):
     for i, line in enumerate(lines):
         if line.startswith('EXPECT: '):
             assertions.append(line.split()[1:])
-        elif line.startswith('[') and line.endswith(')') and '@' in line:
+        elif line.startswith('[') and line.endswith(')') and ('@' in line or '#' in line):
             if assertions and line_contains(line, assertions[0]):
                 assertions = assertions[1:]
         elif line == 'CHECK EXPECTATIONS COMPLETED' or i == len(lines) - 1:


### PR DESCRIPTION
libwayland change their debug output format, which broke out tests. This should keep us compatible with both the old and the new.

Fixes #182 

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
