### PR TITLE
xdg-popup-surface: avoid setting window_geometry with no buffer attached

### DIFF
--- a/src/xdg-popup-surface.c
+++ b/src/xdg-popup-surface.c
@@ -188,11 +188,6 @@ xdg_popup_surface_map (CustomShellSurface *super, struct wl_surface *wl_surface)
     xdg_positioner_destroy (positioner);
 
     xdg_popup_surface_maybe_grab (self, gdk_window);
-    xdg_surface_set_window_geometry (self->xdg_surface,
-                                     self->geom.x,
-                                     self->geom.y,
-                                     self->geom.width,
-                                     self->geom.height);
 }
 
 static void

--- a/src/xdg-popup-surface.c
+++ b/src/xdg-popup-surface.c
@@ -162,6 +162,7 @@ xdg_popup_surface_map (CustomShellSurface *super, struct wl_surface *wl_surface)
     g_return_if_fail (xdg_wm_base_global);
     struct xdg_positioner *positioner = xdg_wm_base_create_positioner (xdg_wm_base_global);
     self->geom = gtk_window_get_priv_logical_geom (gtk_window);
+    self->cached_allocation = (GdkRectangle){0};
     enum xdg_positioner_anchor anchor = gdk_gravity_get_xdg_positioner_anchor(self->position.rect_anchor);
     enum xdg_positioner_gravity gravity = gdk_gravity_get_xdg_positioner_gravity(self->position.window_anchor);
     enum xdg_positioner_constraint_adjustment constraint_adjustment =
@@ -272,12 +273,7 @@ xdg_popup_surface_new (GtkWindow *gtk_window, XdgPopupPosition const* position)
     custom_shell_surface_init ((CustomShellSurface *)self, gtk_window);
 
     self->position = *position;
-    self->cached_allocation = (GdkRectangle) {
-        .x = 0,
-        .y = 0,
-        .width = 0,
-        .height = 0,
-    };
+    self->cached_allocation = (GdkRectangle){0};
     self->xdg_surface = NULL;
     self->xdg_popup = NULL;
 

--- a/test/mock-server/mock-server.h
+++ b/test/mock-server/mock-server.h
@@ -34,6 +34,7 @@ void* alloc_zeroed(size_t size);
 #define NEW_ID_ARG(name, index) ASSERT(type_code_at_index(message, index) == 'n'); uint32_t name = args[index].n;
 #define RESOURCE_ARG(type, name, index) ASSERT(type_code_at_index(message, index) == 'o'); ASSERT(message->types[index] == &type##_interface); struct wl_resource* name = (struct wl_resource*)args[index].o;
 #define UINT_ARG(name, index) ASSERT(type_code_at_index(message, index) == 'u'); uint32_t name = args[index].u;
+#define INT_ARG(name, index) ASSERT(type_code_at_index(message, index) == 'i'); int32_t name = args[index].i;
 
 typedef void (*RequestOverrideFunction)(struct wl_resource* resource, const struct wl_message* message, union wl_argument* args);
 void install_request_override(const struct wl_interface* interface, const char* name, RequestOverrideFunction function);


### PR DESCRIPTION
This PR fixes a protocol error when creating XDG popups on wlroots-git.

Since commit [5dc73937](https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/5dc73937ff96e17a7b4e136a80dfec087604878d) wlroots checks that the effective geometry of all xdg surfaces is nonempty when set. Since effective geometry is always clamped to the size of the attached surface, we can no longer set the window geometry while a nil buffer is attached to the surface.

Remove the call to `xdg_surface_set_window_geometry()` in `xdg_popup_surface_map()`, leaving only the call in
`xdg_popup_surface_on_size_allocate()`.

Fixes #200.

I'm not 100% sure the `xdg_surface_set_window_geometry()` call in `xdg_popup_surface_on_size_allocate()` is always triggered, but it appears to work in my personal testing. I'm open to suggestions for how to better fix this.

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
