### PR TITLE
Fix popup height constraints

### DIFF
--- a/src/gtk-priv-access.h
+++ b/src/gtk-priv-access.h
@@ -37,4 +37,10 @@ GdkRectangle gtk_window_get_priv_logical_geom (GtkWindow *widget);
 // Checks if it is safe to commit wl_surface for the window directly
 gboolean gdk_window_get_priv_pending_commit (GdkWindow *gdk_window);
 
+// Gets window shadow widths
+gint gdk_window_priv_get_shadow_top (GdkWindow *gdk_window);
+gint gdk_window_priv_get_shadow_bottom (GdkWindow *gdk_window);
+gint gdk_window_priv_get_shadow_left (GdkWindow *gdk_window);
+gint gdk_window_priv_get_shadow_right (GdkWindow *gdk_window);
+
 #endif // GDK_WINDOW_HACK_H

--- a/src/xdg-popup-surface.c
+++ b/src/xdg-popup-surface.c
@@ -61,18 +61,29 @@ xdg_popup_handle_configure (void *data,
                             int32_t height)
 {
     XdgPopupSurface *self = data;
+    gint cur_width, cur_height;
     (void)_xdg_popup;
 
     g_return_if_fail(width >= 0 && height >= 0); // Protocol error
 
     // Technically this should not be applied until we get a xdg_surface.configure
     GtkWindow *gtk_window = custom_shell_surface_get_gtk_window ((CustomShellSurface *)self);
-    gtk_window_move (gtk_window, x, y);
-    gtk_window_resize (gtk_window, width, height);
     GdkWindow *gdk_window = gtk_widget_get_window (GTK_WIDGET (gtk_window));
-    g_return_if_fail (gdk_window);
-    // calculating the correct values is hard, but we're not required to provide them
-    g_signal_emit_by_name (gdk_window, "moved-to-rect", NULL, NULL, FALSE, FALSE);
+
+    gtk_window_get_size (gtk_window, &cur_width, &cur_height);
+    width = width == 0 ? cur_width : MIN (cur_width, width);
+    height = height == 0 ? cur_height : MIN (cur_height, height);
+
+    if (gdk_window != NULL) {
+        gint shadow_width = gdk_window_priv_get_shadow_left (gdk_window) + gdk_window_priv_get_shadow_right (gdk_window);
+        gint shadow_height = gdk_window_priv_get_shadow_top (gdk_window) + gdk_window_priv_get_shadow_bottom (gdk_window);
+        gdk_window_move_resize (gdk_window, x, y, width + shadow_width, height + shadow_height);
+        // calculating the correct values is hard, but we're not required to provide them
+        g_signal_emit_by_name (gdk_window, "moved-to-rect", NULL, NULL, FALSE, FALSE);
+    } else {
+        gtk_window_move (gtk_window, x, y);
+        gtk_window_resize (gtk_window, width, height);
+    }
 }
 
 static void

--- a/test/integration-tests/meson.build
+++ b/test/integration-tests/meson.build
@@ -39,4 +39,5 @@ integration_tests = [
     'test-respect-close',
     'test-immediate-close',
     'test-monitor-destroyed-before-configure',
+    'test-popup-honors-compositor-configure-size',
 ]

--- a/test/integration-tests/test-popup-honors-compositor-configure-size.c
+++ b/test/integration-tests/test-popup-honors-compositor-configure-size.c
@@ -12,7 +12,7 @@
 
 #include "integration-test-common.h"
 
-#define PANEL_HEIGHT 50
+#define PANEL_HEIGHT 120
 
 static GtkWindow* window;
 
@@ -33,7 +33,7 @@ static void handle_button_press(GtkWidget *window, GdkEventButton *event)
 static void callback_0()
 {
     EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 0 0);
-    EXPECT_MESSAGE(.create_buffer 1920 50); // size must match DEFAULT_OUTPUT_WIDTH in common.h, PANEL_HEIGHT above
+    EXPECT_MESSAGE(.create_buffer 1920 120); // size must match DEFAULT_OUTPUT_WIDTH in common.h, PANEL_HEIGHT above
 
     window = create_default_window();
     gtk_widget_add_events(GTK_WIDGET(window), GDK_BUTTON_PRESS_MASK);
@@ -60,12 +60,8 @@ static void callback_1()
     EXPECT_MESSAGE(zwlr_layer_surface_v1 .get_popup xdg_popup);
     EXPECT_MESSAGE(xdg_popup .grab);
 
-    // The mock compositor always sends 500x500 in the xdg_popup configure
-    // event.  GTK will add on pixels for shadow widths.  This works on my
-    // machine, but I assume it could be theme-dependent.  Unfortunately, I the
-    // tests don't seem to have access to gtk-priv, so I can't get the shadow
-    // widths here.
-    EXPECT_MESSAGE(.create_buffer 512);
+    // The mock compositor always sends 500x500 in the xdg_popup configure event.
+    EXPECT_MESSAGE(.set_window_geometry 500);
 
     send_command("click_latest_surface 50 25", "latest_surface_clicked");
 }

--- a/test/integration-tests/test-popup-honors-compositor-configure-size.c
+++ b/test/integration-tests/test-popup-honors-compositor-configure-size.c
@@ -1,0 +1,76 @@
+/* This entire file is licensed under MIT
+ *
+ * Copyright 2020 Sophie Winter
+ * Copyright 2026 Brian Tarricone
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "integration-test-common.h"
+
+#define PANEL_HEIGHT 50
+
+static GtkWindow* window;
+
+static void handle_button_press(GtkWidget *window, GdkEventButton *event)
+{
+    GtkWidget* menu = gtk_menu_new();
+    gtk_menu_attach_to_widget(GTK_MENU(menu), window, NULL);
+
+    for (gint i = 0; i < 100; ++i) {
+        GtkWidget* item = gtk_menu_item_new_with_label("menu item");
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), item);
+    }
+
+    gtk_widget_show_all(menu);
+    gtk_menu_popup_at_widget(GTK_MENU(menu), GTK_WIDGET(window), GDK_GRAVITY_SOUTH, GDK_GRAVITY_NORTH, (GdkEvent *)event);
+}
+
+static void callback_0()
+{
+    EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 0 0);
+    EXPECT_MESSAGE(.create_buffer 1920 50); // size must match DEFAULT_OUTPUT_WIDTH in common.h, PANEL_HEIGHT above
+
+    window = create_default_window();
+    gtk_widget_add_events(GTK_WIDGET(window), GDK_BUTTON_PRESS_MASK);
+
+    gtk_layer_init_for_window(window);
+    gtk_layer_set_layer(window, GTK_LAYER_SHELL_LAYER_TOP);
+    gtk_layer_set_namespace(window, "panel");
+    gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_TOP, TRUE);
+    gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
+    gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_RIGHT, TRUE);
+    gtk_layer_set_exclusive_zone(window, PANEL_HEIGHT);
+
+    gtk_widget_set_size_request(GTK_WIDGET(window), -1, PANEL_HEIGHT);
+
+    g_signal_connect(window, "button-press-event", G_CALLBACK(handle_button_press), NULL);
+
+    gtk_widget_show_all(GTK_WIDGET(window));
+}
+
+static void callback_1()
+{
+    EXPECT_MESSAGE(xdg_wm_base .get_xdg_surface);
+    EXPECT_MESSAGE(xdg_surface .get_popup nil);
+    EXPECT_MESSAGE(zwlr_layer_surface_v1 .get_popup xdg_popup);
+    EXPECT_MESSAGE(xdg_popup .grab);
+
+    // The mock compositor always sends 500x500 in the xdg_popup configure
+    // event.  GTK will add on pixels for shadow widths.  This works on my
+    // machine, but I assume it could be theme-dependent.  Unfortunately, I the
+    // tests don't seem to have access to gtk-priv, so I can't get the shadow
+    // widths here.
+    EXPECT_MESSAGE(.create_buffer 512);
+
+    send_command("click_latest_surface 50 25", "latest_surface_clicked");
+}
+
+TEST_CALLBACKS(
+    callback_0,
+    callback_1,
+)


### PR DESCRIPTION
If a popup menu has enough items to be taller than the output/screen size, the compositor may send a configure event telling the client the max height of the menu.  However, gtk_window_move()/gtk_window_resize() doesn't trigger a code path that actually honors the passed size in some cases.

Using gdk_window_move_resize() does trigger the right code path, and menus are constrained properly.    We also need to add in the shadow widths/heights, as the GdkWindow considers them a part of its geometry, while from the GtkWindow's perspective, the passed geometry doesn't include shadows.

If the widget is not yet realized (and thus no GdkWindow is available), we fall back to gtk_window_move()/gtk_window_resize().

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
